### PR TITLE
feat(seo): Establish comprehensive SEO metadata foundation

### DIFF
--- a/relayr-ui/src/app/layout.tsx
+++ b/relayr-ui/src/app/layout.tsx
@@ -39,7 +39,34 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Relayr",
   description:
-    "A fast and secure file transfer app powered by WebSocket technology.",
+    "A fast, simple, and direct file transfer app powered by WebSocket technology. Instantly send files between devices with ease.",
+  keywords: [
+    "file-transfer",
+    "websocket",
+    "fast",
+    "simple",
+    "relayr",
+    "direct",
+  ],
+  openGraph: {
+    title: "Relayr",
+    description:
+      "A fast, simple, and direct file transfer app powered by WebSocket technology. Instantly send files between devices with ease.",
+    url: "https://relayr.rifuki.dev",
+    siteName: "Relayr",
+    type: "website",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
 };
 
 // Root layout component

--- a/relayr-ui/src/app/robots.ts
+++ b/relayr-ui/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://relayr.rifuki.dev/sitemap.xml",
+  };
+}

--- a/relayr-ui/src/app/sitemap.ts
+++ b/relayr-ui/src/app/sitemap.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://relayr.rifuki.dev",
+      lastModified: "2025-06-26T20:11:20.022Z",
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+
+    {
+      url: "https://relayr.rifuki.dev/transfer/send",
+      lastModified: "2025-06-26T20:11:20.022Z",
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+
+    {
+      url: "https://relayr.rifuki.dev/transfer/receive",
+      lastModified: "2025-06-26T20:11:20.022Z",
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
- Generates a static /sitemap.xml from sitemap.ts to guide search engines in discovering all pages, their modification dates, and priorities.
- Creates a static /robots.txt from robots.ts to define site-wide crawling rules for search engine bots.
- Adds a default robots meta tag (`<meta name="robots" content="index, follow">`) to the root layout for explicit page-level indexing instructions.
- Enriches the root layout with strategic keywords and Open Graph (OG) tags for content relevance and social media sharing.

These changes work in concert to build a robust SEO foundation, significantly improving the site's visibility, crawlability, and presentation across search engines and social media platforms.
