### PR TITLE
feat(ci): add workflow_dispatch trigger and branch tagging for Docker builds

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -5,6 +5,7 @@ on:
     branches: ["dev", "main"]
   pull_request:
     branches: ["dev", "main"]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -118,8 +119,8 @@ jobs:
   #
   api-docker:
     name: "🐳 API - Build & Push Docker Image"
-    # Only run on push events to main branch (skip for PR to save resources and time)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Only run on push events to main branch (skip for PR to save resources and time) or on manual dispatch
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
     # Wait for CI jobs to pass before deploying
     needs: [api-ci, ui-ci]
     runs-on: ubuntu-latest
@@ -164,13 +165,15 @@ jobs:
           file: ./relayr-api/Dockerfile
           # Support both AMD64 and ARM64 architectures
           # Use only AMD64 for non-main branches to save resources
-          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          # Tag with both latest and commit SHA for better versioning
+          platforms: ${{ (github.ref == 'refs/heads/main') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          # Tag with both latest and commit SHA and branch name for better versioning
           tags: |
             ${{ env.IMAGE_API_DOCKERHUB }}:latest
             ${{ env.IMAGE_API_DOCKERHUB }}:${{ github.sha }}
+            ${{ env.IMAGE_API_DOCKERHUB }}:${{ github.ref_name }}
             ${{ env.IMAGE_API_GHCR }}:latest
             ${{ env.IMAGE_API_GHCR }}:${{ github.sha }}
+            ${{ env.IMAGE_API_GHCR }}:${{ github.ref_name }}
           push: true
           # Use cache to speed up builds
           cache-from: type=local,src=/tmp/.buildx-cache-api
@@ -187,8 +190,8 @@ jobs:
 
   ui-docker:
     name: "🐳 UI - Build & Push Docker Image"
-    # Only run on push events to main branch (skip for PR to save resources and time)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Only run on push events to main branch (skip for PR to save resources and time) or on manual dispatch
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch')
     # Wait for CI jobs to pass before deploying
     needs: [api-ci, ui-ci]
     runs-on: ubuntu-latest
@@ -232,16 +235,17 @@ jobs:
           file: ./relayr-ui/Dockerfile
           # Support both AMD64 and ARM64 architectures
           # Use only AMD64 for non-main branches to save resources
-          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          # Build arguments for Next.js API
+          platforms: ${{ (github.ref == 'refs/heads/main') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL }}
-          # Tag with both latest and commit SHA for better versioning
+          # Tag with both latest and commit SHA and branch name for better versioning
           tags: |
             ${{ env.IMAGE_UI_DOCKERHUB }}:latest
             ${{ env.IMAGE_UI_DOCKERHUB }}:${{ github.sha }}
+            ${{ env.IMAGE_UI_DOCKERHUB }}:${{ github.ref_name }}
             ${{ env.IMAGE_UI_GHCR }}:latest
             ${{ env.IMAGE_UI_GHCR }}:${{ github.sha }}
+            ${{ env.IMAGE_UI_GHCR }}:${{ github.ref_name }}
           push: true
           # Use cache to speed up builds
           cache-from: type=local,src=/tmp/.buildx-cache-ui


### PR DESCRIPTION
This commit enhances the CI/CD pipeline by introducing manual workflow triggers and improving Docker image traceability. Previously, Docker builds were only triggered automatically on pushes to the main branch, and image tagging lacked branch context, making ad-hoc testing and image identification less flexible.

With this change, developers can now run the workflow manually from any branch using `workflow_dispatch`. Docker images are tagged not only with `latest` and the commit SHA, but also with the branch name using `${{ github.ref_name }}`. Platform selection logic is clarified to ensure multi-arch builds on `main` and `linux/amd64` on other branches.

Key Changes:

**CI/CD:**
- Added `workflow_dispatch` trigger to allow manual workflow runs from the Actions tab.
- Updated Docker build jobs to run on push to main or manual dispatch from any branch.
- Tag Docker images with `latest`, commit SHA, and branch name for better traceability.
- Improved platform selection logic for Docker builds: multi-arch on `main`, amd64 on others.

**Developer Experience:**
- Enables ad-hoc image builds and pushes for testing or preview from any branch without merging.
- Makes it easier to identify which branch an image was built from.

**Operations:**
- No breaking changes; production flow for main branch remains unchanged.
