### PR TITLE
feat(build): introduce unified Docker Compose and multi-arch builds

### DIFF
--- a/build-local-prod.sh
+++ b/build-local-prod.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+ENV_FILE="./relayr-ui/env.production"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Environment file $ENV_FILE does not exist."
+  exit 1
+fi
+
+echo "Start building production image..."
+docker compose --env-file "$ENV_FILE" up --build -d
+echo "Production image built and running."
+

--- a/directori.txt
+++ b/directori.txt
@@ -1,0 +1,232 @@
+.
+├── .github
+│   └── workflows
+│       └── ci-cd.yaml
+├── .gitignore
+├── build-local-prod.sh
+├── context.ts
+├── directori.txt
+├── docker-compose.yaml
+├── relayr-api
+│   ├── .cargo
+│   │   └── config.toml
+│   ├── .dockerignore
+│   ├── .env.example
+│   ├── .gitignore
+│   ├── build-docker-multi-arch.sh
+│   ├── Cargo.lock
+│   ├── Cargo.toml
+│   ├── Dockerfile
+│   ├── README.md
+│   └── src
+│       ├── common
+│       │   ├── mod.rs
+│       │   └── response
+│       │       ├── error.rs
+│       │       ├── mod.rs
+│       │       └── success.rs
+│       ├── config.rs
+│       ├── feature
+│       │   ├── mod.rs
+│       │   └── relay
+│       │       ├── error.rs
+│       │       ├── handlers.rs
+│       │       ├── macros.rs
+│       │       ├── mod.rs
+│       │       ├── routes.rs
+│       │       ├── state.rs
+│       │       ├── types.rs
+│       │       └── ws
+│       │           ├── dto
+│       │           │   ├── mod.rs
+│       │           │   ├── request.rs
+│       │           │   └── response.rs
+│       │           ├── mod.rs
+│       │           ├── peer_disconnect.rs
+│       │           ├── ping.rs
+│       │           ├── read_handlers.rs
+│       │           ├── read.rs
+│       │           ├── socket.rs
+│       │           ├── task_manager.rs
+│       │           └── write.rs
+│       ├── lib.rs
+│       ├── main.rs
+│       └── routes.rs
+└── relayr-ui
+    ├── .dockerignore
+    ├── .env.development
+    ├── .env.example
+    ├── .env.production
+    ├── .gitignore
+    ├── build-docker-multi-arch.sh
+    ├── Caddyfile
+    ├── components.json
+    ├── Dockerfile
+    ├── env.d.ts
+    ├── eslint.config.mjs
+    ├── next-env.d.ts
+    ├── next.config.ts
+    ├── package-lock.json
+    ├── package.json
+    ├── postcss.config.mjs
+    ├── public
+    │   ├── file.svg
+    │   ├── globe.svg
+    │   ├── image.gif
+    │   ├── next.svg
+    │   ├── vercel.svg
+    │   └── window.svg
+    ├── README.md
+    ├── scripts
+    │   ├── get-local-ip.ts
+    │   └── set-local-ip.ts
+    ├── src
+    │   ├── app
+    │   │   ├── dev
+    │   │   │   ├── layout.tsx
+    │   │   │   └── localstorage
+    │   │   │       ├── LocalStorage.tsx
+    │   │   │       └── page.tsx
+    │   │   ├── favicon.ico
+    │   │   ├── globals.css
+    │   │   ├── layout.tsx
+    │   │   ├── not-found.tsx
+    │   │   ├── page.tsx
+    │   │   ├── robots.ts
+    │   │   ├── sitemap.ts
+    │   │   └── transfer
+    │   │       ├── layout.tsx
+    │   │       ├── receive
+    │   │       │   ├── LazyReceivePage.tsx
+    │   │       │   ├── page.tsx
+    │   │       │   └── Receive.tsx
+    │   │       └── send
+    │   │           ├── LazySendPage.tsx
+    │   │           ├── page.tsx
+    │   │           └── Send.tsx
+    │   ├── components
+    │   │   ├── animations
+    │   │   │   └── motion-button.tsx
+    │   │   ├── file-transfer
+    │   │   │   ├── commons
+    │   │   │   │   ├── HeaderConnectionStatus.tsx
+    │   │   │   │   ├── index.ts
+    │   │   │   │   └── WebSocketStatusIndicator.tsx
+    │   │   │   ├── ErrorAlert.tsx
+    │   │   │   ├── receiver
+    │   │   │   │   ├── index.ts
+    │   │   │   │   ├── ReceiverFlow.tsx
+    │   │   │   │   ├── states
+    │   │   │   │   │   ├── CardState.tsx
+    │   │   │   │   │   ├── FileMetaError.tsx
+    │   │   │   │   │   ├── FileMetaLoading.tsx
+    │   │   │   │   │   └── MissingSenderId.tsx
+    │   │   │   │   ├── step-config.ts
+    │   │   │   │   └── steps
+    │   │   │   │       ├── index.ts
+    │   │   │   │       ├── Step1_ReadyToReceive.tsx
+    │   │   │   │       ├── Step2_WaitForSender.tsx
+    │   │   │   │       ├── Step3_Receiving.tsx
+    │   │   │   │       └── Step4_TransferCompleted.tsx
+    │   │   │   ├── sender
+    │   │   │   │   ├── index.ts
+    │   │   │   │   ├── SenderFlow.tsx
+    │   │   │   │   ├── step-config.ts
+    │   │   │   │   └── steps
+    │   │   │   │       ├── index.ts
+    │   │   │   │       ├── Step1_FileSelector.tsx
+    │   │   │   │       ├── Step2_FileSelected.tsx
+    │   │   │   │       ├── Step3_WaitForReceiver.tsx
+    │   │   │   │       ├── Step4_ReadyToSend.tsx
+    │   │   │   │       ├── Step5_Sending.tsx
+    │   │   │   │       └── Step6_TransferCompleted.tsx
+    │   │   │   ├── shareable-link
+    │   │   │   │   ├── CopyButton.tsx
+    │   │   │   │   ├── index.tsx
+    │   │   │   │   └── QrButton.tsx
+    │   │   │   ├── shared
+    │   │   │   │   ├── FileInfoCard.tsx
+    │   │   │   │   ├── index.ts
+    │   │   │   │   ├── step-types.ts
+    │   │   │   │   ├── StepButtonsSection.tsx
+    │   │   │   │   ├── StepHeaderSection.tsx
+    │   │   │   │   ├── StepInfoSection.tsx
+    │   │   │   │   ├── StepNoticeSection.tsx
+    │   │   │   │   ├── StepSectionWrapper.tsx
+    │   │   │   │   └── StepTransferProgressSection.tsx
+    │   │   │   ├── TransferCardLayout.tsx
+    │   │   │   └── WebSocketConnectionStatus.tsx
+    │   │   ├── Footer.tsx
+    │   │   ├── Header.tsx
+    │   │   ├── loading
+    │   │   │   └── ExperienceLoading.tsx
+    │   │   ├── motion-primitives
+    │   │   │   ├── animated-number.tsx
+    │   │   │   ├── initial-transition-loader.tsx
+    │   │   │   ├── sliding-number.tsx
+    │   │   │   ├── text-loop.tsx
+    │   │   │   ├── text-shimmer.tsx
+    │   │   │   └── transition-panel.tsx
+    │   │   ├── ThemeToggle.tsx
+    │   │   └── ui
+    │   │       ├── alert.tsx
+    │   │       ├── badge.tsx
+    │   │       ├── button.tsx
+    │   │       ├── card.tsx
+    │   │       ├── input.tsx
+    │   │       ├── label.tsx
+    │   │       ├── popover.tsx
+    │   │       ├── progress.tsx
+    │   │       ├── sonner.tsx
+    │   │       └── tooltip.tsx
+    │   ├── hooks
+    │   │   ├── query
+    │   │   │   └── useRelay.ts
+    │   │   ├── useApiErrorParser.ts
+    │   │   └── useInitId.ts
+    │   ├── lib
+    │   │   ├── animations.ts
+    │   │   ├── api
+    │   │   │   ├── api-url.ts
+    │   │   │   ├── axios-instance.ts
+    │   │   │   ├── endpoints.ts
+    │   │   │   ├── get-api-url.ts
+    │   │   │   ├── index.ts
+    │   │   │   └── services
+    │   │   │       ├── index.ts
+    │   │   │       └── relayServices.ts
+    │   │   ├── constants.ts
+    │   │   ├── send-next-chunk.ts
+    │   │   └── utils.ts
+    │   ├── listeners
+    │   │   ├── ConnectionStatusListener.tsx
+    │   │   └── websocket
+    │   │       ├── handlers
+    │   │       │   ├── receiver.ts
+    │   │       │   └── sender.ts
+    │   │       ├── ReceiverWebSocketListener.tsx
+    │   │       └── SenderWebSocketListener.tsx
+    │   ├── providers
+    │   │   ├── ReceiverWebSocketProvider.tsx
+    │   │   ├── SenderWebSocketProvider.tsx
+    │   │   ├── TanStackProvider.tsx
+    │   │   └── ThemeProvider.tsx
+    │   ├── stores
+    │   │   ├── useConnectionStore.ts
+    │   │   ├── useFileReceiverStore.ts
+    │   │   └── useFileSenderStore.ts
+    │   ├── types
+    │   │   ├── api.ts
+    │   │   ├── file.ts
+    │   │   └── webSocketMessages
+    │   │       ├── index.ts
+    │   │       ├── receiver.ts
+    │   │       ├── sender.ts
+    │   │       └── shared.ts
+    │   └── utils
+    │       ├── clipboard.ts
+    │       ├── file.ts
+    │       └── local-storage.ts
+    └── tsconfig.json
+
+49 directories, 181 files

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  relayr-api:
+    build:
+      context: ./relayr-api
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: relayr-api
+    image: ghcr.io/rifuki/relayr/relayr-api:latest
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  relayr-ui:
+    depends_on:
+      - relayr-api
+    build:
+      context: ./relayr-ui
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+    platform: linux/amd64
+    container_name: relayr-ui
+    image: ghcr.io/rifuki/relayr/relayr-ui:latest
+    ports:
+      - "3000:80"
+    restart: unless-stopped

--- a/relayr-api/Dockerfile
+++ b/relayr-api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM rust:alpine AS builder
+FROM rust:1.88-alpine AS builder
 ARG TARGETPLATFORM
 WORKDIR /usr/src/app
 
@@ -8,28 +8,28 @@ RUN apk add --no-cache musl-dev build-base gcc binutils
 
 # Set up target - use native compilation for the target platform
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-      rustup target add x86_64-unknown-linux-musl; \
-      echo "x86_64-unknown-linux-musl" > /tmp/target; \
-    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-      rustup target add aarch64-unknown-linux-musl; \
-      echo "aarch64-unknown-linux-musl" > /tmp/target; \
-    else \
-      echo "Unsupported platform: $TARGETPLATFORM" && exit 1; \
-    fi
+    rustup target add x86_64-unknown-linux-musl; \
+    echo "x86_64-unknown-linux-musl" > /tmp/target; \
+  elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    rustup target add aarch64-unknown-linux-musl; \
+    echo "aarch64-unknown-linux-musl" > /tmp/target; \
+  else \
+    echo "Unsupported platform: $TARGETPLATFORM" && exit 1; \
+  fi
 
 # Copy manifest and cache deps
 COPY Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs
 RUN TARGET=$(cat /tmp/target) && \
-    cargo build --release --target $TARGET --locked && \
-    rm -rf src 
+  cargo build --release --target $TARGET --locked && \
+  rm -rf src 
 
 # Copy actual source code and build binary
 COPY . .
 RUN TARGET=$(cat /tmp/target) && \
-    cargo build --release --target $TARGET --locked && \
-    strip target/$TARGET/release/relayr-api && \
-    cp target/$TARGET/release/relayr-api ./relayr-api
+  cargo build --release --target $TARGET --locked && \
+  strip target/$TARGET/release/relayr-api && \
+  cp target/$TARGET/release/relayr-api ./relayr-api
 
 # Stage 2: Distroless runtime
 FROM gcr.io/distroless/static:nonroot

--- a/relayr-api/build-docker-multi-arch.sh
+++ b/relayr-api/build-docker-multi-arch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker buildx build . \
+  --platform linux/amd64,linux/arm64 \
+  --tag ghcr.io/rifuki/relayr/relayr-api:latest \
+  --tag ghcr.io/rifuki/relayr/relayr-api:$(git rev-parse --short HEAD) \
+  --push
+

--- a/relayr-api/build_image.sh
+++ b/relayr-api/build_image.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-docker buildx build . \
-  --platform linux/amd64,linux/arm64 \
-  --tag ghcr.io/rifuki/relayr-api:latest \
-  --tag ghcr.io/rifuki/relayr-api:$(git rev-parse --short HEAD) \
-  --push
-

--- a/relayr-api/docker-compose.yaml
+++ b/relayr-api/docker-compose.yaml
@@ -1,9 +1,0 @@
-services:
-  api:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: relayr-api
-    image: ghcr.io/rifuki/relayr/relayr-api:latest
-    ports:
-      - "8080:8080"

--- a/relayr-ui/.env.example
+++ b/relayr-ui/.env.example
@@ -1,1 +1,3 @@
+COMPOSE_BAKE=true
+
 NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/relayr-ui/Caddyfile
+++ b/relayr-ui/Caddyfile
@@ -1,5 +1,12 @@
 :80 {
     root * /usr/share/caddy
+
+    try_files {path} {path}/index.html {path}.html
+
     file_server
-    try_files {path} {path}.html /404.html
+
+    handle_errors {
+      rewrite * /404.html
+      file_server
+    }
 }

--- a/relayr-ui/Dockerfile
+++ b/relayr-ui/Dockerfile
@@ -1,10 +1,10 @@
 # Build stage: install dependencies and build the Next.js app
-FROM node:latest AS builder
+FROM node:22-alpine AS builder
 WORKDIR /usr/src/app
 
 # Copy package.json and install dependencies
 COPY package.json ./
-RUN npm install 
+RUN npm ci
 
 # Copy all source code and build for production
 COPY . .

--- a/relayr-ui/build-docker-multi-arch.sh
+++ b/relayr-ui/build-docker-multi-arch.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export $(grep -v '^#' .env.production | xargs) 
+
+docker buildx build . \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL \
+  --tag ghcr.io/rifuki/relayr/relayr-ui:latest \
+  --tag ghcr.io/rifuki/relayr/relayr-ui:$(git rev-parse --short HEAD) \
+  --push

--- a/relayr-ui/build_image.sh
+++ b/relayr-ui/build_image.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-docker buildx build . \
-  --platform linux/amd64,linux/arm64 \
-  --tag ghcr.io/rifuki/relayr-ui:latest \
-  --tag ghcr.io/rifuki/relayr-ui:$(git rev-parse --short HEAD) \
-  --push

--- a/relayr-ui/docker-compose.yaml
+++ b/relayr-ui/docker-compose.yaml
@@ -1,9 +1,0 @@
-services:
-  ui:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: relayr-ui
-    image: ghcr.io/rifuki/rifuki/relayr-ui:latest
-    ports:
-      - "3000:80"


### PR DESCRIPTION
Introduced a root-level `docker-compose.yaml` and new multi-architecture build scripts to unify and streamline the local and production build processes for all services.

- Added `build-local-prod.sh` for easy local production builds using Docker Compose.
- Implemented multi-arch build scripts for `relayr-api` and `relayr-ui`, ensuring images can run on different CPU architectures (e.g., amd64, arm64).
- Updated `relayr-api` and `relayr-ui` Dockerfiles for improved reproducibility and platform targeting.
- Enhanced the `relayr-ui` Caddyfile for better static file serving and error page handling.
- Updated `.env.example` for `relayr-ui` to include new build-related variables.

BREAKING CHANGE: The legacy `build_image.sh` scripts and the subproject-level `docker-compose.yaml` files have been removed. All builds must now be performed using the new root-level `docker-compose.yaml` or the new multi-arch build scripts.
